### PR TITLE
Fix wrong answer

### DIFF
--- a/rust-exam/questions.json
+++ b/rust-exam/questions.json
@@ -222,7 +222,7 @@
             "b": "Yes, the displayed content is 110 110",
             "c": "No, the x variable does not have any ownership anymore when println!()",
             "d": "No, the y variable cannot be modified",
-            "answer": "c"
+            "answer": "a"
         },
         {
             "question": "Does the following code compile ?",


### PR DESCRIPTION
The code specified in the question actually compiles and produces
100 110, as shown here: https://play.rust-lang.org/?version=stable&mode=debug&edition=2018&gist=b8fd2c68cb2b5c48d48e510cdbdd6578
This happens because u32 implements Copy trait, so y = x is not transferring variable ownership.