### PR TITLE
Update questions.json

### DIFF
--- a/rust-exam/questions.json
+++ b/rust-exam/questions.json
@@ -158,7 +158,7 @@
             "code": "fn get_value(x: u32) {\nx + 5;\n}\n\nfn main() {\nprintln!(\"{}\", get_value(10));\n}",
             "a": "Yes",
             "b": "No, the x argument of the function get_value is not mutable",
-            "c": "No, function missing return value",
+            "c": "No, function signature missing return value",
             "d": "No, the returned value of get_value cannot be a parameter of the println! macro",
             "answer": "d"
         },

--- a/rust-exam/questions.json
+++ b/rust-exam/questions.json
@@ -155,12 +155,12 @@
         },
         {
             "question": "Does the following code compile ?",
-            "code": "fn get_value(x: u32) {\nx + 5\n}\n\nfn main() {\nprintln!(\"{}\", get_value(10));\n}",
+            "code": "fn get_value(x: u32) {\nx + 5;\n}\n\nfn main() {\nprintln!(\"{}\", get_value(10));\n}",
             "a": "Yes",
             "b": "No, the x argument of the function get_value is not mutable",
-            "c": "No, the semicolon is missing after x + 5",
+            "c": "No, function missing return value",
             "d": "No, the returned value of get_value cannot be a parameter of the println! macro",
-            "answer": "a"
+            "answer": "d"
         },
         {
             "question": "What means a `-> !` return type ?",


### PR DESCRIPTION
Dearest Maintainer,

I checked this answer and corrected it. I changed the code and question because there was two correct answers.

https://play.rust-lang.org/?version=stable&mode=debug&edition=2018&gist=d69639f3332f561274c943ea2581c301
```
fn get_value(x: u32) {
x + 5
}

fn main() {
println!("{}", get_value(10));
}
```

```
   Compiling playground v0.0.1 (/playground)
error[E0308]: mismatched types
 --> src/main.rs:2:1
  |
1 | fn get_value(x: u32) {
  |                      - help: try adding a return type: `-> u32`
2 | x + 5
  | ^^^^^ expected `()`, found `u32`

error[E0277]: `()` doesn't implement `std::fmt::Display`
 --> src/main.rs:6:16
  |
6 | println!("{}", get_value(10));
  |                ^^^^^^^^^^^^^ `()` cannot be formatted with the default formatter
  |
  = help: the trait `std::fmt::Display` is not implemented for `()`
  = note: in format strings you may be able to use `{:?}` (or {:#?} for pretty-print) instead
  = note: required by `std::fmt::Display::fmt`
  = note: this error originates in a macro (in Nightly builds, run with -Z macro-backtrace for more info)
```

Thanks. It is fun.
Becker